### PR TITLE
feat(3.2): in-app update check with Adw.Banner

### DIFF
--- a/lsmm/core/updater.py
+++ b/lsmm/core/updater.py
@@ -1,0 +1,58 @@
+"""GitHub release checker — debounced to once per 24h, silent on failure."""
+import json
+import logging
+import time
+import urllib.error
+from pathlib import Path
+
+from lsmm.core import net
+from lsmm.core.version import APP_VERSION
+
+log = logging.getLogger(__name__)
+
+_RELEASES_URL = "https://api.github.com/repos/pyromeister/Linux-Steam-ModManager/releases/latest"
+_CHECK_INTERVAL = 86400  # 24 h
+_DEBOUNCE_PATH = Path.home() / ".local/state/linux-mod-manager/update_check.json"
+
+
+def _parse_version(tag: str) -> tuple[int, ...]:
+    return tuple(int(x) for x in tag.lstrip("v").split(".") if x.isdigit())
+
+
+def _debounce_ok() -> bool:
+    """Return True if enough time has passed since the last check."""
+    try:
+        data = json.loads(_DEBOUNCE_PATH.read_text())
+        return time.time() - data.get("checked_at", 0) >= _CHECK_INTERVAL
+    except Exception:
+        return True
+
+
+def _record_check() -> None:
+    try:
+        _DEBOUNCE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _DEBOUNCE_PATH.write_text(json.dumps({"checked_at": time.time()}))
+    except Exception:
+        pass
+
+
+def check_for_update() -> tuple[str, str] | None:
+    """Return (tag, html_url) if a newer release exists, else None.
+
+    Silent on any network or parse error.
+    """
+    if not _debounce_ok():
+        return None
+
+    _record_check()
+
+    try:
+        data = json.loads(net.request(_RELEASES_URL, timeout=10))
+        tag = data.get("tag_name", "")
+        url = data.get("html_url", "")
+        if _parse_version(tag) > _parse_version(APP_VERSION):
+            return tag, url
+        return None
+    except (urllib.error.URLError, urllib.error.HTTPError, Exception):
+        log.debug("Update check failed (silent)", exc_info=True)
+        return None

--- a/lsmm/gui/window.py
+++ b/lsmm/gui/window.py
@@ -9,6 +9,7 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Adw, GLib, Gtk, Gio
 
+from lsmm.core.updater import check_for_update
 from lsmm.core.config import (
     get_steam_root, get_steam_candidates,
     get_nexus_api_key,
@@ -54,6 +55,7 @@ class ModManagerWindow(Adw.ApplicationWindow):
         self._build_ui()
         self._update_setup_btn()
         GLib.idle_add(self._init_steam_path)
+        threading.Thread(target=self._check_for_update, daemon=True).start()
 
     def _build_ui(self):
         self.toast_overlay = Adw.ToastOverlay()
@@ -61,6 +63,11 @@ class ModManagerWindow(Adw.ApplicationWindow):
 
         root = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.toast_overlay.set_child(root)
+
+        self.update_banner = Adw.Banner()
+        self.update_banner.set_button_label("Release Notes")
+        self.update_banner.connect("button-clicked", self._on_update_banner_clicked)
+        root.append(self.update_banner)
 
         header = Adw.HeaderBar()
         root.append(header)
@@ -525,6 +532,24 @@ class ModManagerWindow(Adw.ApplicationWindow):
 
     def _on_setup_btn(self, _btn):
         setup_handler.handle_setup_btn(self)
+
+    # ── Update check ──────────────────────────────────────────────────────────
+
+    def _check_for_update(self):
+        result = check_for_update()
+        if result:
+            tag, url = result
+            self._update_release_url = url
+            GLib.idle_add(self._show_update_banner, tag)
+
+    def _show_update_banner(self, tag: str):
+        self.update_banner.set_title(f"Update available: {tag}")
+        self.update_banner.set_revealed(True)
+
+    def _on_update_banner_clicked(self, _banner):
+        url = getattr(self, "_update_release_url", None)
+        if url:
+            Gtk.UriLauncher.new(url).launch(self, None, None, None)
 
     # ── Utilities ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `lsmm/core/updater.py` (new): checks GitHub releases API at startup, debounced to once per 24h via `~/.local/state/linux-mod-manager/update_check.json`, silent on any network/parse failure
- `lsmm/gui/window.py`: adds `Adw.Banner` above the header bar, revealed when a newer release is found; "Release Notes" button opens the release URL via `Gtk.UriLauncher`; check runs in a daemon thread — no UI block

## Test plan

- [ ] Set `APP_VERSION = "0.0.1"` in `lsmm/core/version.py` and launch — banner should appear with the latest tag
- [ ] Relaunch within 24h — no network call made, banner still shown from previous state (or hidden if version reset)
- [ ] Disconnect network and launch — no crash, no visible error
- [ ] Click "Release Notes" button — browser opens GitHub release page

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)