### PR TITLE
feat(3.3): user-extensible game profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Makefile
 .pytest_cache/
 
 # Dev-only docs folder (fully local, never in clone)
-docs/
+docs/*
+!docs/game-profile-schema.md
 lsmm-roadmap.md
 backup/

--- a/docs/game-profile-schema.md
+++ b/docs/game-profile-schema.md
@@ -1,0 +1,66 @@
+# Game Profile Schema
+
+Game profiles are JSON files that tell LSMM how to manage mods for a specific game.
+
+## Location
+
+| Priority | Path |
+|----------|------|
+| 1 (user, takes precedence) | `~/.config/linux-mod-manager/games/<slug>.json` |
+| 2 (bundled) | installed alongside the package in `lsmm/games/` |
+
+Drop a file in the user directory to add a new game or override a bundled profile.
+The `<slug>` becomes the internal identifier (e.g. `oblivion`, `skyrim_se`).
+
+## Required fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display name shown in the UI |
+| `steam_app_id` | string | Steam application ID (find at store.steampowered.com) |
+| `engine` | string | Engine plugin — see [Engines](#engines) |
+| `game_exe` | string | Game executable filename (e.g. `Starfield.exe`) |
+| `install_subdir` | string | Subfolder name inside the Steam library (e.g. `Starfield`) |
+
+## Optional fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `nexus_domain` | string | Nexus Mods game domain (e.g. `starfield`) — enables NXM links |
+| `mod_dir` | string | Subdirectory inside the game folder where mods are installed (default: `Data`) |
+| `script_extender` | object | See [Script extender](#script-extender) |
+
+## Engines
+
+| Value | Games |
+|-------|-------|
+| `bethesda` | Starfield, Skyrim SE, Fallout 4 — manages `Plugins.txt` |
+| `modfolder` | Stardew Valley (SMAPI), 7 Days to Die — copies files into mod folder |
+| `bepinex` | Planet Crafter, Craftopia — Unity + BepInEx |
+| `rimworld` | RimWorld — reads/writes `ModsConfig.xml` |
+
+## Script extender
+
+Only relevant for `bethesda` engine games that have a script extender.
+
+```json
+"script_extender": {
+  "name": "SFSE",
+  "loader_exe": "sfse_loader.exe",
+  "plugins_dir": "Data/SFSE/Plugins"
+}
+```
+
+## Full example
+
+```json
+{
+  "name": "Oblivion Remastered",
+  "steam_app_id": "2623190",
+  "engine": "bethesda",
+  "game_exe": "OblivionRemastered.exe",
+  "install_subdir": "Oblivion Remastered",
+  "nexus_domain": "oblivionremastered",
+  "mod_dir": "OblivionRemastered/Content/Dev/ObvData/Data"
+}
+```

--- a/lsmm/core/config.py
+++ b/lsmm/core/config.py
@@ -10,6 +10,7 @@ from importlib.resources import files as _pkg_files
 from pathlib import Path
 
 GAMES_DIR = Path(str(_pkg_files("lsmm").joinpath("games")))
+USER_GAMES_DIR = Path.home() / ".config/linux-mod-manager/games"
 APP_CONFIG_PATH = Path.home() / ".config/linux-mod-manager/config.json"
 ARCHIVES_DIR = Path.home() / ".local/share/linux-mod-manager/archives"
 BACKUPS_DIR = Path.home() / ".local/share/linux-mod-manager/backups"
@@ -118,7 +119,10 @@ def find_library_for_app(app_id: str | int) -> Path | None:
 
 
 def load_profile(game: str) -> dict:
-    """Load game profile from games/<game>.json."""
+    """Load game profile — user override (~/.config/linux-mod-manager/games/) takes precedence."""
+    user_path = USER_GAMES_DIR / f"{game}.json"
+    if user_path.exists():
+        return json.loads(user_path.read_text())
     path = GAMES_DIR / f"{game}.json"
     if not path.exists():
         available = [p.stem for p in GAMES_DIR.glob("*.json")]

--- a/lsmm/core/utils.py
+++ b/lsmm/core/utils.py
@@ -2,7 +2,7 @@
 
 import json
 
-from lsmm.core.config import load_profile, GAMES_DIR
+from lsmm.core.config import load_profile, GAMES_DIR, USER_GAMES_DIR
 
 
 def load_engine(game: str):
@@ -25,19 +25,26 @@ def load_engine(game: str):
 
 
 def available_games() -> list:
-    result = []
-    for p in sorted(GAMES_DIR.glob("*.json")):
-        data = json.loads(p.read_text())
-        result.append((p.stem, data["name"]))
-    return result
+    games: dict[str, str] = {}
+    for p in GAMES_DIR.glob("*.json"):
+        try:
+            games[p.stem] = json.loads(p.read_text())["name"]
+        except Exception:
+            continue
+    if USER_GAMES_DIR.exists():
+        for p in USER_GAMES_DIR.glob("*.json"):
+            try:
+                games[p.stem] = json.loads(p.read_text())["name"]
+            except Exception:
+                continue
+    return sorted(games.items())
 
 
 def find_game_by_nexus_domain(domain: str) -> str | None:
-    for p in GAMES_DIR.glob("*.json"):
+    for slug, _ in available_games():
         try:
-            data = json.loads(p.read_text())
-            if data.get("nexus_domain", "").lower() == domain.lower():
-                return p.stem
+            if load_profile(slug).get("nexus_domain", "").lower() == domain.lower():
+                return slug
         except Exception:
             continue
     return None

--- a/lsmm/gui/dialogs/help.py
+++ b/lsmm/gui/dialogs/help.py
@@ -31,6 +31,10 @@ def show_help_dialog(win):
             "<b>NXM URL</b> (experimental)\n"
             'Click "NXM URL", paste an <tt>nxm://</tt> link from Nexus Mods. '
             "Requires a free Nexus API key (nexusmods.com → Account → API Keys).\n\n"
+            "<b>Custom game profiles</b>\n"
+            "Drop a <tt>&lt;slug&gt;.json</tt> file into "
+            "<tt>~/.config/linux-mod-manager/games/</tt> to add a new game or override a "
+            "bundled profile. The file format is documented on GitHub.\n\n"
             '<a href="https://github.com/pyromaster/linux-sfse-modlauncher">'
             "GitHub Repository</a>"
         ),


### PR DESCRIPTION
## Summary

- `lsmm/core/config.py`: added `USER_GAMES_DIR = ~/.config/linux-mod-manager/games/`; `load_profile()` checks user dir before bundled
- `lsmm/core/utils.py`: `available_games()` merges bundled + user profiles (user overrides by slug); `find_game_by_nexus_domain()` reuses merged result
- `lsmm/gui/dialogs/help.py`: added note about custom game profiles directory
- `docs/game-profile-schema.md`: full JSON schema reference (required fields, optional fields, engines, script extender, full example)
- `.gitignore`: `docs/` → `docs/*` to allow whitelisting individual committed docs

## Test plan

- [ ] Drop `~/.config/linux-mod-manager/games/skyrim_se.json` with modified content → overrides bundled version in UI
- [ ] Drop `~/.config/linux-mod-manager/games/oblivion.json` → new game appears in the game list without code changes
- [ ] Remove user override → reverts to bundled profile
- [ ] Help dialog shows custom game profiles paragraph

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)