### PR TITLE
feat(gui): 4.2-4.4 mod metadata, Update All, better NXM errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ fill that gap with a proper native tool.
 - Install mods from `.zip`, `.7z`, and `.rar` archives
 - **NXM URL import** *(experimental)* — paste an `nxm://` link from Nexus Mods for direct download + install (requires free Nexus API key)
 - **Update check** — "Check Updates" button queries Nexus Mods API for newer versions of installed mods (NXM-imported only; requires API key)
+- **Update All** — after checking for updates, a results dialog lets you update all mods at once or open browser tabs for manual downloads
+- **Mod metadata in list** — version and file size displayed below each mod name in the mod list
+- **Better NXM error messages** — expiry detection, and specific messages for 403/404/410 responses
+- **In-app LSMM update check** — an info banner appears automatically when a new LSMM release is published on GitHub
 - **Progress bar** — install and download operations show a progress bar; NXM downloads display real percentage, file installs use pulse mode
 - **Games panel** — dedicated left column lists all game profiles; click to switch game, import external profiles via "Add", remove profiles via "Remove"
+- **Custom game profiles** — add your own game JSON profiles to `~/.config/linux-mod-manager/games/` without touching the installation; see [Game Profile Schema](https://github.com/pyromeister/Linux-Steam-ModManager/wiki/Game-Profile-Schema)
 - **Mod profiles** — save and restore named loadouts (active mods + load order) per game; "Save" button updates the selected profile in-place
 - **Launch game** — launch the selected game directly from the GUI
 - **Mod list search & sort** — alphabetic sort with live search filter
@@ -66,19 +71,29 @@ fill that gap with a proper native tool.
 ```bash
 git clone https://github.com/pyromeister/Linux-Steam-ModManager
 cd Linux-Steam-ModManager
+pip install .
 ```
 
-No pip dependencies — standard library only (GUI requires system GTK4 packages, see Requirements).
+This installs the `lsmm` and `lsmm-gui` entry points.
+GTK4 and libadwaita must be installed as system packages (see Requirements above) — they are not pip-installable.
+
+For development (includes pytest, flake8):
+
+```bash
+pip install ".[dev]"
+```
 
 ---
 
 ## Usage — GUI
 
 ```bash
+lsmm-gui
+# or without installing:
 python3 modlauncher-gui.py
 ```
 
-Select your game from the dropdown. The load order panel appears automatically
+Select your game from the games panel on the left. The load order panel appears automatically
 for games that support it (Bethesda games). Use **+ Install** to open a file
 chooser — you can select multiple archives at once and they will be installed
 sequentially.
@@ -88,10 +103,10 @@ sequentially.
 ## Usage — CLI
 
 ```bash
-python3 modlauncher.py --game starfield list
-python3 modlauncher.py --game starfield install ~/Downloads/SomeMod.zip
-python3 modlauncher.py --game starfield uninstall MyModName
-python3 modlauncher.py games
+lsmm --game starfield list
+lsmm --game starfield install ~/Downloads/SomeMod.zip
+lsmm --game starfield uninstall MyModName
+lsmm games
 ```
 
 Full command reference: [CLI Reference](https://github.com/pyromeister/Linux-Steam-ModManager/wiki/CLI-Reference)
@@ -109,6 +124,13 @@ Full command reference: [CLI Reference](https://github.com/pyromeister/Linux-Ste
 Full list with engine and script extender details: [Supported Games](https://github.com/pyromeister/Linux-Steam-ModManager/wiki/Supported-Games)
 
 Want a game added? [Open a Game Request](https://github.com/pyromeister/Linux-Steam-ModManager/issues/new?template=game_request.yml)
+
+### Custom Game Profiles
+
+You can add support for any game without modifying the installation. Drop a JSON file into
+`~/.config/linux-mod-manager/games/` and LSMM will pick it up on next launch.
+
+Schema reference and examples: [Game Profile Schema](https://github.com/pyromeister/Linux-Steam-ModManager/wiki/Game-Profile-Schema)
 
 ---
 

--- a/lsmm/engines/bepinex.py
+++ b/lsmm/engines/bepinex.py
@@ -288,7 +288,7 @@ class BepInExEngine(BaseEngine):
 
             # BepInEx itself gets a special "framework" kind
             kind = "framework" if name == "BepInEx" else "mod"
-            result.append({"name": name, "active": active, "plugins": [], "kind": kind})
+            result.append({"name": name, "active": active, "plugins": [], "kind": kind, "nexus": entry.get("nexus")})
 
         # If BepInEx is installed on disk but not in manifest, show it as untracked
         bepinex_tracked = any(e.get("name") == "BepInEx" or n == "BepInEx"

--- a/lsmm/engines/bethesda.py
+++ b/lsmm/engines/bethesda.py
@@ -155,7 +155,10 @@ class BethesdaEngine(BaseEngine):
                 (p := plugin_lookup.get(Path(f).name)) and p.active
                 for f in plugins
             ) if plugins else True
-            result.append({"name": name, "active": active, "plugins": plugins, "kind": "mod"})
+            result.append({
+                "name": name, "active": active, "plugins": plugins,
+                "kind": "mod", "nexus": entry.get("nexus"),
+            })
 
         if self.paths.se_plugins_dir and self.paths.se_plugins_dir.exists():
             for dll in sorted(self.paths.se_plugins_dir.glob(f"*{DLL_EXTENSION}")):

--- a/lsmm/engines/modfolder.py
+++ b/lsmm/engines/modfolder.py
@@ -275,7 +275,7 @@ class ModFolderEngine(BaseEngine):
                         tracked_dirs.add(rel.parts[0].removesuffix(".disabled"))
                 except ValueError:
                     pass
-            result.append({"name": mod_name, "active": active, "kind": "mod"})
+            result.append({"name": mod_name, "active": active, "kind": "mod", "nexus": entry.get("nexus")})
 
         # Show untracked subdirectories in mods_dir
         if self.mods_dir.exists():

--- a/lsmm/engines/rimworld.py
+++ b/lsmm/engines/rimworld.py
@@ -223,6 +223,7 @@ class RimWorldEngine(BaseEngine):
             result.append({
                 "name": mod_name, "display": about["name"],
                 "packageId": about["packageId"], "active": active, "plugins": [],
+                "nexus": entry.get("nexus"),
             })
 
         # Untracked mods in Mods/ dir

--- a/lsmm/gui/dialogs/update_results.py
+++ b/lsmm/gui/dialogs/update_results.py
@@ -12,7 +12,8 @@ def show_update_results(window, updates: list, errors: list):
     lines = []
     if updates:
         lines.append("<b>Updates available:</b>")
-        for name, _old, new_ver in updates:
+        for row in updates:
+            name, new_ver = row[0], row[2]
             lines.append(f"  • {name}  →  {new_ver}")
     if errors:
         if lines:
@@ -26,4 +27,16 @@ def show_update_results(window, updates: list, errors: list):
     dialog.set_body("\n".join(lines))
     dialog.add_response("ok", "OK")
     dialog.set_default_response("ok")
+
+    if updates:
+        dialog.add_response("update_all", "Update All")
+        dialog.set_response_appearance("update_all", Adw.ResponseAppearance.SUGGESTED)
+
+        def on_response(d, response):
+            if response == "update_all":
+                from lsmm.gui.handlers.updates import update_all_async
+                update_all_async(window, updates)
+
+        dialog.connect("response", on_response)
+
     dialog.present()

--- a/lsmm/gui/handlers/nxm.py
+++ b/lsmm/gui/handlers/nxm.py
@@ -1,4 +1,5 @@
 import threading
+import time
 
 import gi
 gi.require_version("Gtk", "4.0")
@@ -6,6 +7,17 @@ from gi.repository import GLib
 
 from lsmm.core.config import ARCHIVES_DIR
 from lsmm.core.installer import ConflictError
+
+
+def _nxm_error_message(exc: Exception) -> str:
+    msg = str(exc)
+    if "403" in msg:
+        return "Nexus API key invalid or missing — get one at nexusmods.com → Account → API Keys"
+    if "404" in msg:
+        return "Mod or file not found on Nexus (may have been removed or made private)"
+    if "410" in msg:
+        return "This file has been permanently removed from Nexus Mods"
+    return f"NXM import failed: {exc}"
 
 
 def do_nxm_import(window, url: str, api_key: str):
@@ -16,15 +28,26 @@ def do_nxm_import(window, url: str, api_key: str):
         window._toast("Invalid NXM URL — expected nxm://...")
         return
 
+    if nxm.get("expires") and int(nxm["expires"]) < int(time.time()):
+        window._toast("This Nexus download link has expired — click the download button again on Nexus Mods")
+        return
+
     def run():
         try:
             GLib.idle_add(window.status_label.set_text, "Getting download link from Nexus...")
-            dl_url = get_download_link(nxm, api_key)
+            try:
+                dl_url = get_download_link(nxm, api_key)
+            except Exception as link_err:
+                GLib.idle_add(window._progress_done)
+                GLib.idle_add(window.status_label.set_text, "Ready")
+                GLib.idle_add(window._toast, _nxm_error_message(link_err))
+                return
 
             filename = dl_url.split("/")[-1].split("?")[0]
             slug = window._game_slug or "unknown"
             dest = ARCHIVES_DIR / slug / filename
 
+            file_entry = None
             try:
                 files = get_mod_files(nxm["game_domain"], nxm["mod_id"], api_key)
                 file_entry = next((f for f in files if f.get("file_id") == nxm["file_id"]), None)
@@ -48,6 +71,10 @@ def do_nxm_import(window, url: str, api_key: str):
                 "mod_id": nxm["mod_id"],
                 "file_id": nxm["file_id"],
             }
+            if file_entry:
+                for key in ("version", "size_kb", "uploaded_timestamp"):
+                    if file_entry.get(key) is not None:
+                        nexus_meta[key] = file_entry[key]
             try:
                 window.engine.install(dest, nexus_meta=nexus_meta)
             except ConflictError as ce:

--- a/lsmm/gui/handlers/updates.py
+++ b/lsmm/gui/handlers/updates.py
@@ -2,7 +2,11 @@ import threading
 
 import gi
 gi.require_version("Gtk", "4.0")
-from gi.repository import GLib
+gi.require_version("Adw", "1")
+from gi.repository import GLib, Gtk
+
+from lsmm.core.config import ARCHIVES_DIR, get_nexus_api_key
+from lsmm.core.installer import ConflictError
 
 
 def do_check_updates(window, api_key: str):
@@ -30,11 +34,67 @@ def do_check_updates(window, api_key: str):
                         mod_name,
                         str(nx.get("file_id", "?")),
                         latest.get("version") or str(latest.get("file_id", "?")),
+                        nx["game_domain"],
+                        nx["mod_id"],
+                        latest.get("file_id"),
                     ))
             except Exception as e:
                 errors.append(f"{mod_name}: {e}")
 
         GLib.idle_add(window.status_label.set_text, "Ready")
         GLib.idle_add(show_update_results, window, updates, errors)
+
+    threading.Thread(target=run, daemon=True).start()
+
+
+def update_all_async(window, updates: list):
+    from lsmm.core.nexus import get_download_link, download_file
+
+    api_key = get_nexus_api_key()
+
+    def run():
+        browser_mods = []
+        for mod_name, _old_fid, _new_ver, game_domain, mod_id, new_file_id in updates:
+            nxm = {"game_domain": game_domain, "mod_id": mod_id, "file_id": new_file_id}
+            try:
+                GLib.idle_add(window.status_label.set_text, f"Updating {mod_name}…")
+                dl_url = get_download_link(nxm, api_key)
+                filename = dl_url.split("/")[-1].split("?")[0]
+                slug = window._game_slug or "unknown"
+                dest = ARCHIVES_DIR / slug / filename
+
+                def on_progress(downloaded, total):
+                    if total > 0:
+                        GLib.idle_add(window._progress_set, downloaded / total)
+
+                GLib.idle_add(window._progress_set, 0.0)
+                download_file(dl_url, dest, on_progress=on_progress)
+                GLib.idle_add(window._progress_start_pulse)
+                try:
+                    window.engine.install(dest)
+                except ConflictError:
+                    window.engine.install(dest, force=True)
+            except Exception as e:
+                if "403" in str(e):
+                    browser_mods.append((game_domain, mod_id, mod_name))
+                else:
+                    GLib.idle_add(window._toast, f"Update failed for {mod_name}: {e}")
+
+        if browser_mods:
+            GLib.idle_add(
+                window._toast,
+                f"Free account: opening {len(browser_mods)} mod page(s) in browser…",
+            )
+            for game_domain, mod_id, _name in browser_mods:
+                url = f"https://www.nexusmods.com/{game_domain}/mods/{mod_id}"
+                GLib.idle_add(
+                    Gtk.UriLauncher.new(url).launch, window, None, None, None
+                )
+
+        GLib.idle_add(window._progress_done)
+        GLib.idle_add(window.status_label.set_text, "Ready")
+        if not browser_mods:
+            GLib.idle_add(window._refresh_mods)
+            GLib.idle_add(window._toast, "All mods updated")
 
     threading.Thread(target=run, daemon=True).start()

--- a/lsmm/gui/widgets/mod_row.py
+++ b/lsmm/gui/widgets/mod_row.py
@@ -45,3 +45,17 @@ class ModRow(Gtk.ListBoxRow):
             sub.add_css_class("dim-label")
             sub.add_css_class("caption")
             label_box.append(sub)
+
+        nexus = mod.get("nexus")
+        if nexus:
+            parts = []
+            if nexus.get("version"):
+                parts.append(f"v{nexus['version']}")
+            if nexus.get("size_kb"):
+                parts.append(f"{nexus['size_kb'] / 1024:.1f} MB")
+            if parts:
+                meta = Gtk.Label(label="  ".join(parts))
+                meta.set_xalign(0)
+                meta.add_css_class("dim-label")
+                meta.add_css_class("caption")
+                label_box.append(meta)


### PR DESCRIPTION
## Summary

- **4.4 — Better NXM errors:** expiry check before download starts; 403/404/410 mapped to specific messages via `_nxm_error_message()` helper
- **4.2 — Mod metadata in list:** NXM handler stores `version`/`size_kb`/`uploaded_timestamp` in `nexus_meta`; all four engines pass `nexus` field through `list_mods()`; `ModRow` shows version + file size as a dim caption below the mod name
- **4.3 — Update All:** `check_update` tuple extended with `game_domain`/`mod_id`/`new_file_id`; `update_all_async()` tries premium API download per mod and falls back to browser tabs on 403; update results dialog gains a suggested "Update All" button
- **README:** new features listed, corrected installation instructions (`pip install .`), `lsmm`/`lsmm-gui` entry points documented

## Test plan

- [ ] Install a mod via NXM URL — verify version + size appear below mod name in the list
- [ ] Paste an expired NXM link — verify specific expiry toast (not generic error)
- [ ] Use an invalid API key — verify "API key invalid or missing" toast on 403
- [ ] Open Check Updates with a mod that has an update — verify "Update All" button appears
- [ ] Click Update All with a free account — verify browser tabs open for each outdated mod
- [ ] Click Update All with a premium account — verify mods download and install automatically

🤖 Generated with [Claude Code](https://claude.ai/code)