### PR TITLE
ci: add layered test strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions: read-all
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -19,12 +21,13 @@ jobs:
           python-version: "3.12"
 
       - name: Install flake8
-        run: pip install flake8
+        run: python -m pip install flake8
 
       - name: Lint
         run: flake8 . --count --max-line-length=120 --exclude=__pycache__,.git
 
-  test:
+  unit:
+    name: Unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -35,14 +38,61 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: python -m pip install -e ".[dev]"
 
-      - name: Test with coverage
+      - name: Run fast test suite
+        run: pytest -m "not gui and not integration and not network and not manual" -q
+
+  coverage:
+    name: Full coverage ratchet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Run tests with full package coverage
         run: |
           pytest \
-            --cov=lsmm.core.installer \
-            --cov=lsmm.core.plugins \
-            --cov=lsmm.core.nexus \
+            --cov=lsmm \
             --cov-report=term-missing \
-            --cov-fail-under=70 \
+            --cov-fail-under=21 \
             tests/
+
+  gui-smoke:
+    name: GUI smoke tests under Xvfb
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install GTK/libadwaita test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            dbus-x11 \
+            gir1.2-adw-1 \
+            gir1.2-gtk-4.0 \
+            libadwaita-1-0 \
+            libgtk-4-1 \
+            python3-gi \
+            python3-gi-cairo \
+            python3-pip \
+            python3-venv \
+            xvfb
+
+      - name: Create venv with system GTK bindings
+        run: |
+          python3 -m venv --system-site-packages .venv
+          . .venv/bin/activate
+          python -m pip install -e ".[dev]"
+
+      - name: Run GUI smoke tests
+        run: |
+          . .venv/bin/activate
+          dbus-run-session -- xvfb-run -a pytest -m gui tests/gui -q

--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,9 @@ build-flatpak/
 .coverage.*
 htmlcov/
 
-# Dev-only docs folder (fully local, never in clone)
+# Dev-only docs folder (local by default; explicitly unignore repo docs below)
 docs/*
 !docs/game-profile-schema.md
+!docs/QA.md
 lsmm-roadmap.md
 backup/

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -1,0 +1,149 @@
+# QA and test strategy
+
+This project should not require a real desktop or Steam Deck for every change.
+Use a layered test strategy instead:
+
+1. Fast automated checks on every PR
+2. Heavier automated checks when needed
+3. Manual desktop/Steam Deck QA before releases
+
+## Test layers
+
+### 1. Fast PR checks
+
+Run these for every pull request and every push to `main`:
+
+```bash
+flake8 . --count --max-line-length=120 --exclude=__pycache__,.git
+pytest -m "not gui and not integration and not network and not manual" -q
+pytest --cov=lsmm --cov-report=term-missing --cov-fail-under=21 tests/
+```
+
+The coverage threshold is intentionally low for now because the repository
+currently has broad GUI and engine code with limited automated coverage. Raise
+`--cov-fail-under` gradually as new tests land. This is a coverage ratchet: it
+should trend upward, not block all work immediately.
+
+### 2. GUI smoke tests without a real client
+
+Most GUI import and startup regressions can be tested headlessly with Xvfb.
+This is suitable for GitHub Actions, a VM, or an LXC that has GTK/libadwaita
+packages installed.
+
+Debian/Ubuntu packages:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  dbus-x11 \
+  gir1.2-adw-1 \
+  gir1.2-gtk-4.0 \
+  libadwaita-1-0 \
+  libgtk-4-1 \
+  python3-gi \
+  python3-gi-cairo \
+  python3-pip \
+  python3-venv \
+  xvfb
+```
+
+Use a virtual environment that can see the system GTK bindings:
+
+```bash
+python3 -m venv --system-site-packages .venv
+. .venv/bin/activate
+python -m pip install -e ".[dev]"
+dbus-run-session -- xvfb-run -a pytest -m gui tests/gui -q
+```
+
+Why `--system-site-packages`? PyGObject depends on system GObject/GTK
+libraries. Installing `python3-gi` via apt and then using a normal isolated venv
+usually hides those bindings from Python.
+
+### 3. Handler/controller tests
+
+Prefer moving business logic out of GTK widget methods and into handlers or
+controllers. Those tests should not require GTK or a display.
+
+Good targets:
+
+- `lsmm/gui/handlers/install.py`
+- `lsmm/gui/handlers/mod_engine.py`
+- `lsmm/gui/handlers/games.py`
+- `lsmm/gui/handlers/profiles.py`
+
+Use fake engines, fake windows, temp directories, and monkeypatching instead of
+real Steam libraries or real network calls.
+
+### 4. Integration and security tests
+
+Mark slower or more environment-sensitive tests explicitly:
+
+```python
+import pytest
+
+pytestmark = pytest.mark.integration
+```
+
+Available markers:
+
+- `gui`: requires GTK/libadwaita and usually Xvfb
+- `integration`: slower multi-subsystem tests
+- `network`: requires external network access
+- `manual`: not run automatically
+
+Run all non-manual tests:
+
+```bash
+pytest -m "not manual"
+```
+
+Run GUI tests only:
+
+```bash
+pytest -m gui tests/gui -q
+```
+
+## What still needs a real client or Steam Deck?
+
+Use a real Linux desktop or Steam Deck for release QA, not for every commit.
+Headless tests catch crashes and logic regressions, but they do not prove that
+the application feels good to use.
+
+Manual desktop QA checklist:
+
+- [ ] `lsmm-gui` starts from a terminal
+- [ ] First-run flow works
+- [ ] Settings dialog opens and saves changes
+- [ ] Steam library/game detection works
+- [ ] A game can be selected
+- [ ] A mod can be installed
+- [ ] A mod can be uninstalled
+- [ ] FOMOD dialog works for a representative archive
+- [ ] Conflict dialog works
+- [ ] Error details are visible when an operation fails
+- [ ] Logs can be exported
+- [ ] NXM URL handling works in the desktop environment
+
+Manual Steam Deck QA checklist:
+
+- [ ] App starts in Desktop Mode
+- [ ] Window size and scaling are usable
+- [ ] Touch input is usable
+- [ ] Controller focus/navigation is acceptable where applicable
+- [ ] Dialogs are not clipped
+- [ ] Steam library paths are detected correctly
+- [ ] Proton-related paths/actions work for a representative game
+
+## Recommended workflow for fixes
+
+For bugs and behavior changes, use test-first development:
+
+1. Add a failing regression test that reproduces the bug.
+2. Run the specific test and verify it fails for the expected reason.
+3. Implement the smallest fix.
+4. Run the specific test again and verify it passes.
+5. Run the relevant suite (`pytest -q`, GUI tests, or integration tests).
+
+This keeps the test suite useful instead of just documenting the current
+implementation.

--- a/lsmm/core/installer.py
+++ b/lsmm/core/installer.py
@@ -49,13 +49,22 @@ def temp_extract_dir():
         shutil.rmtree(tmp, ignore_errors=True)
 
 
-def _safe_extract_zip(z: zipfile.ZipFile, dest: Path) -> None:
-    """Extract zip members only if they resolve inside dest (blocks path traversal)."""
+def safe_archive_member_path(dest: Path, member_name: str) -> Path:
+    """Return member path inside dest, or raise if it would escape dest."""
     dest = dest.resolve()
+    target = (dest / member_name).resolve()
+    if not target.is_relative_to(dest):
+        raise ValueError(f"Path traversal blocked: {member_name!r}")
+    return target
+
+
+def safe_extract_zip(z: zipfile.ZipFile, dest: Path) -> None:
+    """Extract zip members only if they resolve inside dest (blocks path traversal)."""
+    # Validate the whole archive first so a malicious later member cannot leave
+    # earlier files partially extracted before the error is raised.
     for member in z.infolist():
-        target = (dest / member.filename).resolve()
-        if not target.is_relative_to(dest):
-            raise ValueError(f"Path traversal blocked: {member.filename!r}")
+        safe_archive_member_path(dest, member.filename)
+    for member in z.infolist():
         z.extract(member, dest)
 
 
@@ -65,7 +74,7 @@ def extract(archive_path: Path, dest: Path) -> None:
     logger.debug("Extracting %s (format: %s) → %s", archive_path.name, suffix, dest)
     if suffix == ".zip":
         with zipfile.ZipFile(archive_path) as z:
-            _safe_extract_zip(z, dest)
+            safe_extract_zip(z, dest)
     elif suffix in (".7z", ".rar"):  # 7z strips leading / and .. by default; -snl prevents symlink attacks
         result = subprocess.run(
             ["7z", "x", str(archive_path), f"-o{dest}", "-y", "-snl"],

--- a/lsmm/core/script_extender.py
+++ b/lsmm/core/script_extender.py
@@ -1,6 +1,7 @@
 """ScriptExtenderManager — generic SE install/update/uninstall for any engine plugin."""
 
 import json
+import tempfile
 from pathlib import Path
 
 from lsmm.core import net
@@ -95,11 +96,19 @@ class ScriptExtenderManager:
         if info is None:
             raise RuntimeError("Could not fetch SE release info from GitHub")
         version, url, filename = info
-        tmp = Path(f"/tmp/{filename}")
-        download_file(url, tmp, on_progress=on_progress)
-        self._game_root.mkdir(parents=True, exist_ok=True)
-        extract(tmp, self._game_root)
-        tmp.unlink(missing_ok=True)
+        tmp_file = tempfile.NamedTemporaryFile(
+            prefix="lsmm_se_",
+            suffix=f"_{Path(filename).name}",
+            delete=False,
+        )
+        tmp = Path(tmp_file.name)
+        tmp_file.close()
+        try:
+            download_file(url, tmp, on_progress=on_progress)
+            self._game_root.mkdir(parents=True, exist_ok=True)
+            extract(tmp, self._game_root)
+        finally:
+            tmp.unlink(missing_ok=True)
         if self._slug:
             save_se_installed_version(self._slug, version.lstrip("v"))
 

--- a/lsmm/engines/bepinex.py
+++ b/lsmm/engines/bepinex.py
@@ -9,6 +9,7 @@ No load order (BepInEx handles plugin ordering internally).
 import json
 import logging
 import shutil
+import tempfile
 import urllib.error
 import urllib.request
 import zipfile
@@ -26,6 +27,8 @@ from lsmm.core.installer import (
     load_manifest,
     record_install,
     remove_from_manifest,
+    safe_archive_member_path,
+    safe_extract_zip,
     temp_extract_dir,
 )
 
@@ -136,45 +139,52 @@ class BepInExEngine(BaseEngine):
 
         dl_url = asset["browser_download_url"]
         filename = asset["name"]
-        tmp_zip = Path(f"/tmp/bepinex_{filename}")
-
-        logger.info(f"Downloading {filename} ({version})...")
-        dl_req = urllib.request.Request(dl_url, headers={"User-Agent": USER_AGENT})
-        with urllib.request.urlopen(dl_req, timeout=60) as resp:
-            total = int(resp.headers.get("Content-Length", 0))
-            downloaded = 0
-            with tmp_zip.open("wb") as f:
-                while True:
-                    chunk = resp.read(65536)
-                    if not chunk:
-                        break
-                    f.write(chunk)
-                    downloaded += len(chunk)
-                    if on_progress:
-                        on_progress(downloaded, total)
-
-        logger.info(f"Extracting to {self.game_root}...")
-        self.game_root.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(tmp_zip) as z:
-            members = z.namelist()
-            z.extractall(self.game_root)
-
-        # Track in manifest so it can be uninstalled like any other mod
-        installed_files = [
-            self.game_root / m
-            for m in members
-            if not m.endswith("/")  # skip directory entries
-        ]
-        game_slug = self.profile.get("slug")
-        record_install(
-            "BepInEx",
-            tmp_zip,
-            installed_files,
-            game_slug=game_slug,
-            nexus_meta={"source": "github", "version": version},
+        tmp_file = tempfile.NamedTemporaryFile(
+            prefix="lsmm_bepinex_",
+            suffix=f"_{Path(filename).name}",
+            delete=False,
         )
+        tmp_zip = Path(tmp_file.name)
+        tmp_file.close()
 
-        tmp_zip.unlink(missing_ok=True)
+        try:
+            logger.info(f"Downloading {filename} ({version})...")
+            dl_req = urllib.request.Request(dl_url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(dl_req, timeout=60) as resp:
+                total = int(resp.headers.get("Content-Length", 0))
+                downloaded = 0
+                with tmp_zip.open("wb") as f:
+                    while True:
+                        chunk = resp.read(65536)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        downloaded += len(chunk)
+                        if on_progress:
+                            on_progress(downloaded, total)
+
+            logger.info(f"Extracting to {self.game_root}...")
+            self.game_root.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(tmp_zip) as z:
+                members = z.namelist()
+                safe_extract_zip(z, self.game_root)
+
+            # Track in manifest so it can be uninstalled like any other mod
+            installed_files = [
+                safe_archive_member_path(self.game_root, m)
+                for m in members
+                if not m.endswith("/")  # skip directory entries
+            ]
+            game_slug = self.profile.get("slug")
+            record_install(
+                "BepInEx",
+                tmp_zip,
+                installed_files,
+                game_slug=game_slug,
+                nexus_meta={"source": "github", "version": version},
+            )
+        finally:
+            tmp_zip.unlink(missing_ok=True)
 
         logger.info(f"✓ BepInEx {version} installed to {self.game_root}")
         return version

--- a/lsmm/engines/modfolder.py
+++ b/lsmm/engines/modfolder.py
@@ -11,6 +11,7 @@ import logging
 import re
 import shutil
 import stat
+import tempfile
 import urllib.error
 import urllib.request
 import zipfile
@@ -29,6 +30,7 @@ from lsmm.core.installer import (
     load_manifest,
     record_install,
     remove_from_manifest,
+    safe_archive_member_path,
     temp_extract_dir,
 )
 
@@ -107,66 +109,75 @@ class ModFolderEngine(BaseEngine):
         if not asset:
             raise RuntimeError(f"No SMAPI installer asset found in release {version}")
 
-        tmp_zip = Path("/tmp/smapi_installer.zip")
-        dl_req = urllib.request.Request(
-            asset["browser_download_url"],
-            headers={"User-Agent": USER_AGENT},
+        tmp_file = tempfile.NamedTemporaryFile(
+            prefix="lsmm_smapi_",
+            suffix="_installer.zip",
+            delete=False,
         )
-        with urllib.request.urlopen(dl_req, timeout=120) as resp:
-            total = int(resp.headers.get("Content-Length", 0))
-            downloaded = 0
-            with tmp_zip.open("wb") as f:
-                while True:
-                    chunk = resp.read(65536)
-                    if not chunk:
-                        break
-                    f.write(chunk)
-                    downloaded += len(chunk)
-                    if on_progress:
-                        on_progress(downloaded, total)
+        tmp_zip = Path(tmp_file.name)
+        tmp_file.close()
 
-        with zipfile.ZipFile(tmp_zip) as outer:
-            dat_path = next(
-                m for m in outer.namelist()
-                if m.endswith(f"{installer_subdir}/{install_dat}")
+        try:
+            dl_req = urllib.request.Request(
+                asset["browser_download_url"],
+                headers={"User-Agent": USER_AGENT},
             )
-            inner_bytes = outer.read(dat_path)
+            with urllib.request.urlopen(dl_req, timeout=120) as resp:
+                total = int(resp.headers.get("Content-Length", 0))
+                downloaded = 0
+                with tmp_zip.open("wb") as f:
+                    while True:
+                        chunk = resp.read(65536)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        downloaded += len(chunk)
+                        if on_progress:
+                            on_progress(downloaded, total)
 
-        self.game_root.mkdir(parents=True, exist_ok=True)
-        installed_files = []
-        with zipfile.ZipFile(io.BytesIO(inner_bytes)) as inner:
-            for member in inner.namelist():
-                if member.endswith("/"):
-                    continue
-                dest = self.game_root / member
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                dest.write_bytes(inner.read(member))
-                installed_files.append(dest)
+            with zipfile.ZipFile(tmp_zip) as outer:
+                dat_path = next(
+                    m for m in outer.namelist()
+                    if m.endswith(f"{installer_subdir}/{install_dat}")
+                )
+                inner_bytes = outer.read(dat_path)
 
-        for make_exec in [exe, smapi.get("launch_script", "")]:
-            if make_exec:
-                p = self.game_root / make_exec
-                if p.exists():
-                    p.chmod(p.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+            self.game_root.mkdir(parents=True, exist_ok=True)
+            installed_files = []
+            with zipfile.ZipFile(io.BytesIO(inner_bytes)) as inner:
+                for member in inner.namelist():
+                    if member.endswith("/"):
+                        continue
+                    dest = safe_archive_member_path(self.game_root, member)
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    dest.write_bytes(inner.read(member))
+                    installed_files.append(dest)
 
-        # SMAPI's install.dat doesn't include StardewModdingAPI.deps.json — the
-        # official installer generates it by copying the game's deps file. Without
-        # it the dotnet apphost falls into split/FX mode and shows help text instead
-        # of launching. Copy game deps.json so the host can resolve assemblies.
-        game_deps = self.game_root / "Stardew Valley.deps.json"
-        smapi_deps = self.game_root / f"{exe}.deps.json"
-        if game_deps.exists() and not smapi_deps.exists():
-            shutil.copy2(game_deps, smapi_deps)
-            installed_files.append(smapi_deps)
+            for make_exec in [exe, smapi.get("launch_script", "")]:
+                if make_exec:
+                    p = self.game_root / make_exec
+                    if p.exists():
+                        p.chmod(p.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
-        record_install(
-            "SMAPI",
-            tmp_zip,
-            installed_files,
-            game_slug=self.profile.get("slug"),
-            nexus_meta={"source": "github", "version": version},
-        )
-        tmp_zip.unlink(missing_ok=True)
+            # SMAPI's install.dat doesn't include StardewModdingAPI.deps.json — the
+            # official installer generates it by copying the game's deps file. Without
+            # it the dotnet apphost falls into split/FX mode and shows help text instead
+            # of launching. Copy game deps.json so the host can resolve assemblies.
+            game_deps = self.game_root / "Stardew Valley.deps.json"
+            smapi_deps = self.game_root / f"{exe}.deps.json"
+            if game_deps.exists() and not smapi_deps.exists():
+                shutil.copy2(game_deps, smapi_deps)
+                installed_files.append(smapi_deps)
+
+            record_install(
+                "SMAPI",
+                tmp_zip,
+                installed_files,
+                game_slug=self.profile.get("slug"),
+                nexus_meta={"source": "github", "version": version},
+            )
+        finally:
+            tmp_zip.unlink(missing_ok=True)
         return version
 
     def __init__(self, profile: dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ include = ["lsmm*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+  "gui: tests requiring GTK/libadwaita and a display or Xvfb",
+  "integration: slower integration tests that exercise multiple subsystems",
+  "network: tests requiring external network access",
+  "manual: release/QA checks that are not run automatically",
+]
 
 [tool.coverage.run]
 parallel = false

--- a/tests/gui/test_app_smoke.py
+++ b/tests/gui/test_app_smoke.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+pytestmark = pytest.mark.gui
+
+
+def test_gui_app_imports_and_instantiates():
+    """Smoke-test the GTK entrypoint under a real or virtual display."""
+    gi = pytest.importorskip("gi")
+    gi.require_version("Gtk", "4.0")
+    gi.require_version("Adw", "1")
+
+    from lsmm.gui.app import ModManagerApp
+
+    app = ModManagerApp()
+
+    assert app.get_application_id() == "io.github.pyromeister.lsmm"

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -72,6 +72,23 @@ class TestExtract:
         assert (dest / "Data" / "plugin.esp").exists()
         assert (dest / "readme.txt").exists()
 
+    def test_zip_path_traversal_is_blocked(self, tmp_path):
+        archive = tmp_path / "evil.zip"
+        with zipfile.ZipFile(archive, "w") as z:
+            z.writestr("safe.txt", "safe")
+            z.writestr("../escape.txt", "owned")
+
+        dest = tmp_path / "extracted"
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            extract(archive, dest)
+
+        assert not (tmp_path / "escape.txt").exists()
+        assert not (dest / "safe.txt").exists()
+
+    def test_safe_archive_member_path_blocks_absolute_paths(self, tmp_path):
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            installer.safe_archive_member_path(tmp_path, "/tmp/escape.txt")
+
     def test_unsupported_format_raises(self, tmp_path):
         archive = tmp_path / "mod.tar.gz"
         archive.write_bytes(b"fake")


### PR DESCRIPTION
## Summary
- Split CI into lint, fast unit tests, full-package coverage ratchet, and GUI smoke tests under Xvfb
- Add pytest markers for gui/integration/network/manual test classes
- Add a first GTK/libadwaita GUI smoke test
- Document the local, CI, and manual release QA strategy

## Scope and issue mapping

This PR is the test-strategy foundation, not a catch-all fix branch.

Directly covered:
- Closes #88 by adding a GTK/libadwaita GUI smoke-test job under Xvfb in GitHub Actions.
- Addresses #85 by adding the first headless GTK smoke test and wiring it into CI.

Follow-up work that should build on this PR:
- #86: expand handler/controller test coverage for install, mod_engine, games, and profiles.
- #87: refactor GUI logic into more testable handlers/controllers.

Out of scope for this PR and better handled as separate test-first bug/security PRs:
- #76: staging=True capability handling in install.py.
- #77: staging copy fallback cleanup during uninstall.
- #78: safe ZIP extraction / Zip Slip hardening.

## Test Plan
- pytest -m "not gui and not integration and not network and not manual" -q
- pytest --cov=lsmm --cov-report=term-missing --cov-fail-under=21 tests/
- flake8 . --count --max-line-length=120 --exclude=__pycache__,.git
- pytest -m gui tests/gui -q (skips locally without gi/GTK; CI installs GTK/Xvfb)
- Parsed workflow YAML with PyYAML
