### PR TITLE
docs: sync README and wiki with current code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,55 +12,79 @@
   <a href="#installation">Install</a> · <a href="#supported-games">Supported Games</a> · <a href="https://github.com/pyromeister/Linux-Steam-ModManager/wiki">Wiki</a> · <a href="https://github.com/pyromeister/Linux-Steam-ModManager/issues">Issues</a>
 </p>
 
-> ⚠️ **Early Alpha.** Core features work (Starfield tested). Not recommended for large mod setups yet.
+> ⚠️ **Alpha software.** Core install/manage flows work for several games, but expect rough edges. Keep backups before using LSMM with large or important mod setups.
 
 ---
 
 ## What it does
 
-LSMM is a native GTK4 mod manager that handles the full mod lifecycle — download, install, enable/disable, uninstall — without Wine or Proton wrappers for the tool itself.
+LSMM is a native GTK4/libadwaita mod manager that handles the mod lifecycle — archive install, enable/disable, load order, uninstall, backups, Nexus downloads, and profile management — without running the manager itself through Wine or Proton.
 
-**Who it's for:** Steam Deck users and Linux gamers who want a real native mod manager instead of running Vortex or MO2 through Wine.
+**Who it's for:** Steam Deck users and Linux gamers who want a native alternative to running Vortex or MO2 through Wine.
 
 ---
 
 ## Features
 
 **Installation**
-- Install from `.zip`, `.7z`, `.rar` archives — auto-detects mod structure
-- **NXM links** — click "Mod Manager Download" on Nexus Mods, LSMM handles the rest
+- Install from `.zip`, `.7z`, and `.rar` archives with automatic structure detection
+- **NXM links** — click “Mod Manager Download” on Nexus Mods and let LSMM handle the download/install flow
 - FOMOD installer support for complex multi-choice mods
 - Conflict detection before install; backup + restore on uninstall
+- Archive cache for installed mods
 
 **Mod management**
-- Enable / disable mods without uninstalling
-- Drag & drop load order reordering
+- Enable/disable mods without uninstalling
+- Drag-and-drop load order reordering where the engine supports it
+- LOOT-assisted sorting for supported Bethesda games when LOOT is installed
 - Search and alphabetic sort in the mod list
-- Mod profiles — save and restore named loadouts per game
+- Named mod profiles/loadouts per game
+- Path overrides for game root, data directory, Proton prefix, and script-extender paths
 
 **Nexus Mods integration**
 - Requires a free [Nexus API key](https://www.nexusmods.com/users/myaccount?tab=api)
-- Import collections, check for updates, update all at once
-- Version and file size shown in the mod list
+- NXM download handling with expiry/error feedback
+- Collection import and collection update checks
+- Mod update checks and “update all” flow
+- Version and file size metadata in the mod list when available
 
-**Under the hood**
-- Multi-library support including SD card (`/run/media`)
-- Linux case-sensitivity fix for Windows-packed archives
-- Script extender detection (SFSE, SKSE, F4SE)
-- LOOT load order sorting for Bethesda games
+**Linux / Steam Deck support**
+- Native Steam, Flatpak Steam, and Snap Steam root detection
+- Multi-library support including SD card libraries under `/run/media`
+- First-run Steam path picker when auto-detection is ambiguous
+- Linux case-sensitivity normalization for common Windows-packed mod folders
+- Script extender detection/setup helpers for supported Bethesda games
+- Self-update checks against GitHub releases, with snooze/disable options
+- Rotating log file at `~/.local/state/linux-mod-manager/lsmm.log`
 
 ---
 
 ## Installation
 
-**Option A — Flatpak** *(coming to Flathub — not yet released)*
+**Option A — Flatpak** *(local build supported; Flathub release not published yet)*
+
+See [`flatpak/README.md`](flatpak/README.md) for local Flatpak build/run instructions and NXM handler notes.
 
 **Option B — from source**
 
-1. Install system dependencies (Ubuntu/Debian):
+1. Install system dependencies.
+
+Ubuntu/Debian:
 
 ```bash
 sudo apt install python3-gi gir1.2-gtk-4.0 gir1.2-adw-1 p7zip-full
+```
+
+Fedora:
+
+```bash
+sudo dnf install python3-gobject gtk4 libadwaita p7zip p7zip-plugins
+```
+
+Arch:
+
+```bash
+sudo pacman -S python-gobject gtk4 libadwaita p7zip
 ```
 
 2. Clone and install:
@@ -71,19 +95,26 @@ cd Linux-Steam-ModManager
 pip install --user .
 ```
 
-Requirements: Python 3.10+, GTK4, libadwaita 1.x, p7zip
+Requirements: Python 3.10+, GTK4, libadwaita 1.x, and 7-Zip/p7zip.
 
 ---
 
 ## Usage
 
-```bash
-lsmm-gui          # open the GUI
-```
+Open the GUI:
 
 ```bash
+lsmm-gui
+```
+
+Basic CLI examples:
+
+```bash
+lsmm games
+lsmm --game starfield check
 lsmm --game starfield install ~/Downloads/SomeMod.zip
 lsmm --game starfield list
+lsmm --game starfield order
 lsmm --game starfield uninstall MyModName
 ```
 
@@ -93,13 +124,16 @@ Full command reference: [CLI Reference](https://github.com/pyromeister/Linux-Ste
 
 ## Supported Games
 
-| Engine | Games |
-|--------|-------|
-| Bethesda | Starfield, Skyrim SE, Fallout 4, Oblivion, Fallout NV, Fallout 3 |
-| BepInEx | Planet Crafter, Craftopia |
-| ModFolder / SMAPI | Stardew Valley (SMAPI auto-install), RimWorld, 7 Days to Die |
+Bundled profiles are generated from `lsmm/games/*.json`.
 
-[Full list with details →](https://github.com/pyromeister/Linux-Steam-ModManager/wiki/Supported-Games)
+| Engine | Bundled games |
+|--------|---------------|
+| Bethesda | Starfield, Skyrim Special Edition, Fallout 4, Fallout: New Vegas |
+| BepInEx | The Planet Crafter, Craftopia |
+| ModFolder / SMAPI | Stardew Valley, 7 Days to Die |
+| RimWorld | RimWorld |
+
+[Full list with profile slugs, App IDs, and testing status →](https://github.com/pyromeister/Linux-Steam-ModManager/wiki/Supported-Games)
 
 Want a game added? [Open a Game Request](https://github.com/pyromeister/Linux-Steam-ModManager/issues/new?template=game_request.yml)
 
@@ -107,7 +141,11 @@ Want a game added? [Open a Game Request](https://github.com/pyromeister/Linux-St
 
 ## Custom Game Profiles
 
-Add any game without modifying the installation — drop a JSON file into `~/.config/linux-mod-manager/games/`.
+Add or override a game without modifying the installation by dropping a JSON profile into:
+
+```text
+~/.config/linux-mod-manager/games/<slug>.json
+```
 
 [Game Profile Schema →](https://github.com/pyromeister/Linux-Steam-ModManager/wiki/Game-Profile-Schema)
 
@@ -115,7 +153,7 @@ Add any game without modifying the installation — drop a JSON file into `~/.co
 
 ## Contributing
 
-Contributions welcome, especially engine plugins for new games.
+Contributions welcome, especially game profiles, engine plugins, testing, packaging, and Steam Deck QA.
 Open an issue before starting large changes.
 
 [Project Structure](https://github.com/pyromeister/Linux-Steam-ModManager/wiki/Project-Structure) · [Adding a New Game](https://github.com/pyromeister/Linux-Steam-ModManager/wiki/Adding-a-New-Game) · [Bethesda Engine Internals](https://github.com/pyromeister/Linux-Steam-ModManager/wiki/Bethesda-Engine-Internals)
@@ -124,6 +162,6 @@ Open an issue before starting large changes.
 
 ## License
 
-GPLv3 — see [LICENSE](LICENSE).
+GPL-3.0-or-later — see [LICENSE](LICENSE).
 
 > Built with [Claude Code](https://claude.ai/code).

--- a/docs/game-profile-schema.md
+++ b/docs/game-profile-schema.md
@@ -2,7 +2,14 @@
 
 Game profiles are JSON files that tell LSMM how to manage mods for a specific game.
 
-Drop a file into `~/.config/linux-mod-manager/games/<slug>.json` to add a game or override a bundled profile without touching the installation.
+## Location
+
+| Priority | Path |
+|----------|------|
+| 1 — user override | `~/.config/linux-mod-manager/games/<slug>.json` |
+| 2 — bundled | installed package data under `lsmm/games/` |
+
+Drop a file in the user directory to add a new game or override a bundled profile without modifying the installation. The `<slug>` is the filename without `.json` and is used with `--game`.
 
 ## Required fields
 
@@ -11,51 +18,161 @@ Drop a file into `~/.config/linux-mod-manager/games/<slug>.json` to add a game o
 | `name` | string | Display name shown in the UI |
 | `steam_app_id` | string | Steam application ID |
 | `engine` | string | Engine plugin — see [Engines](#engines) |
-| `game_exe` | string | Game executable (e.g. `Starfield.exe`) |
-| `install_subdir` | string | Folder name inside the Steam library (e.g. `Starfield`) |
+| `game_exe` | string | Game executable filename |
+| `install_subdir` | string | Folder name inside `steamapps/common/` |
 
-## Optional fields
+## Common optional fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `nexus_domain` | string | Nexus Mods game domain (e.g. `starfield`) — enables NXM links |
-| `mod_dir` | string | Subdirectory inside the game folder where mods land (default: `Data`) |
-| `appdata_name` | string | Override AppData folder name for Plugins.txt (Bethesda only) |
-| `script_extender` | object | See [Script extender](#script-extender) |
+| `nexus_domain` | string | Nexus Mods game domain; enables NXM links and update checks |
+| `appdata_name` | string | AppData folder override for Bethesda `Plugins.txt` paths, e.g. `FalloutNV` |
+| `proton` | boolean | Marks a profile as Proton/Windows-oriented for engine-specific behavior |
+| `script_extender` | object/null | Bethesda script extender metadata; see below |
+| `modfolder` | object | Required for `modfolder` engine profiles |
+| `smapi` | object | Optional SMAPI auto-install metadata for Stardew Valley-style profiles |
+| `bepinex` | object | Optional BepInEx install metadata |
 
 ## Engines
 
 | Value | Use for |
 |-------|---------|
-| `bethesda` | Starfield, Skyrim SE, Fallout 4 — manages Plugins.txt |
-| `modfolder` | Stardew Valley (SMAPI), 7 Days to Die — copies files into mod folder |
-| `bepinex` | Planet Crafter, Craftopia — Unity + BepInEx |
-| `rimworld` | RimWorld — reads/writes ModsConfig.xml |
+| `bethesda` | Starfield, Skyrim SE, Fallout 4, Fallout: New Vegas — manages `Data/` and `Plugins.txt` |
+| `modfolder` | Stardew Valley, 7 Days to Die — copies files into a dedicated mods folder |
+| `bepinex` | The Planet Crafter, Craftopia — Unity + BepInEx |
+| `rimworld` | RimWorld — manages RimWorld mod folders and `ModsConfig.xml` |
 
 ## Script extender
 
-Only needed for `bethesda` games that have a script extender (SFSE, SKSE, F4SE).
+Only for `bethesda` games that have a script extender.
 
 ```json
 "script_extender": {
   "name": "SFSE",
   "loader_exe": "sfse_loader.exe",
-  "plugins_dir": "Data/SFSE/Plugins"
+  "plugins_dir": "Data/SFSE/Plugins",
+  "asset_prefix": "sfse_",
+  "github_repo": "owner/repo"
 }
 ```
 
-## Example
+Known fields:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Short name shown in the UI, e.g. `SFSE`, `SKSE`, `F4SE`, `NVSE` |
+| `loader_exe` | Script extender loader executable inside the game root |
+| `plugins_dir` | Path relative to the game root where SE plugin DLLs live |
+| `github_repo` | GitHub releases repo used by update/install helpers when applicable |
+| `github_tags_repo` | GitHub tags repo used when releases are not available |
+| `asset_prefix` | Release/tag asset prefix used to identify the correct download |
+| `download_page` | Fallback/manual download page shown to the user |
+
+Set `"script_extender": null` or omit it if the game has no script extender.
+
+## ModFolder options
+
+Required when `"engine": "modfolder"`.
+
+```json
+"modfolder": {
+  "mods_dir": "Mods"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `mods_dir` | Subdirectory inside the game folder where mods are placed |
+
+## SMAPI options
+
+Optional. When present, LSMM can install/update SMAPI from GitHub releases.
+
+```json
+"smapi": {
+  "executable": "StardewModdingAPI",
+  "launch_script": "unix-launcher.sh",
+  "github_repo": "Pathoschild/SMAPI",
+  "asset_name": "installer.zip",
+  "installer_subdir": "internal/linux",
+  "install_dat": "install.dat",
+  "game_deps_file": "Stardew Valley.deps.json",
+  "launch_env_prefix": "SMAPI_USE_CURRENT_SHELL=true"
+}
+```
+
+## BepInEx options
+
+Optional metadata used by the BepInEx engine.
+
+```json
+"bepinex": {
+  "plugins_dir": "BepInEx/plugins",
+  "build": "win_x64",
+  "github_repo": "BepInEx/BepInEx"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `plugins_dir` | Plugins folder relative to the game root |
+| `build` | BepInEx build flavor, e.g. `win_x64` |
+| `github_repo` | GitHub repo used for BepInEx release lookup when available |
+
+## Examples
+
+### Bethesda game with script extender
 
 ```json
 {
-  "name": "Oblivion Remastered",
-  "steam_app_id": "2623190",
+  "name": "Starfield",
+  "steam_app_id": "1716740",
   "engine": "bethesda",
-  "game_exe": "OblivionRemastered.exe",
-  "install_subdir": "Oblivion Remastered",
-  "nexus_domain": "oblivionremastered",
-  "mod_dir": "OblivionRemastered/Content/Dev/ObvData/Data"
+  "game_exe": "Starfield.exe",
+  "install_subdir": "Starfield",
+  "nexus_domain": "starfield",
+  "script_extender": {
+    "name": "SFSE",
+    "loader_exe": "sfse_loader.exe",
+    "plugins_dir": "Data/SFSE/Plugins",
+    "asset_prefix": "sfse_",
+    "github_tags_repo": "ianpatt/sfse",
+    "download_page": "https://www.nexusmods.com/starfield/mods/106"
+  }
 }
 ```
 
-The `<slug>` (filename without `.json`) becomes the internal identifier used with `--game` on the CLI.
+### ModFolder game
+
+```json
+{
+  "name": "7 Days to Die",
+  "steam_app_id": "251570",
+  "engine": "modfolder",
+  "game_exe": "7DaysToDie.x86_64",
+  "install_subdir": "7 Days To Die",
+  "nexus_domain": "7daystodie",
+  "modfolder": {
+    "mods_dir": "Mods"
+  }
+}
+```
+
+### BepInEx game
+
+```json
+{
+  "name": "The Planet Crafter",
+  "steam_app_id": "1284190",
+  "engine": "bepinex",
+  "game_exe": "Planet Crafter.exe",
+  "install_subdir": "The Planet Crafter",
+  "nexus_domain": "theplanetcrafter",
+  "proton": true,
+  "bepinex": {
+    "plugins_dir": "BepInEx/plugins",
+    "build": "win_x64",
+    "github_repo": "BepInEx/BepInEx"
+  }
+}
+```

--- a/lsmm/cli.py
+++ b/lsmm/cli.py
@@ -15,14 +15,14 @@ Usage:
   lsmm games                                    (list available games)
 """
 
-import json
 import logging
 import sys
 import argparse
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
-from lsmm.core.config import load_profile, GAMES_DIR, LOG_PATH
+from lsmm.core.config import load_profile, LOG_PATH
+from lsmm.core.utils import available_games
 from lsmm.engines import load_engine
 
 logger = logging.getLogger(__name__)
@@ -119,9 +119,8 @@ def cmd_check(engine, args):
 
 def cmd_games(_engine, _args):
     print("\n── Available Games ─────────────────────")
-    for p in sorted(GAMES_DIR.glob("*.json")):
-        data = json.loads(p.read_text())
-        print(f"  {p.stem:<20} {data['name']}")
+    for slug, name in available_games():
+        print(f"  {slug:<20} {name}")
     print()
 
 


### PR DESCRIPTION
## Summary
- Refresh README against the current codebase: supported games, install notes, Nexus/LOOT/profile features, paths, and current alpha wording
- Expand the in-repo game profile schema with current optional fields (`appdata_name`, `proton`, `bepinex`, SMAPI/script-extender metadata)
- Make `lsmm games` use the shared `available_games()` helper so user-defined profiles are listed consistently with the GUI/docs

## Wiki
The GitHub wiki was updated directly with matching current-state docs:
- Supported Games
- CLI Reference
- Game Profile Schema
- Managed Directories
- Project Structure
- Adding a New Game
- Bethesda Engine Internals

## Test Plan
- [x] `python3 -m pytest -q -m 'not gui'` → 260 passed, 4 deselected
- [x] `python3 -m lsmm.cli games` lists all bundled profiles, including `falloutnv`
